### PR TITLE
blogs and blog post page nav updated

### DIFF
--- a/src/app/(blog)/posts/[slug]/layout.tsx
+++ b/src/app/(blog)/posts/[slug]/layout.tsx
@@ -15,11 +15,12 @@ export default async function PostLayout({
 }) {
 	const posts = await reader.collections.content.all();
 	const post = await reader.collections.content.read(params.slug);
-
 	if (!post) notFound();
 
 	const headings = getHeadingsFromContent(await post.content());
-
+	const navItemList = posts.filter((p)=> {
+		return p.entry.category === post.category
+	})
 	return (
 		<ThreeColumnLayout
 			leftSidebar={
@@ -29,11 +30,12 @@ export default async function PostLayout({
 						{
 							heading: {
 								id: 'posts-heading',
-								label: 'Posts',
+								label: post.category[0].toUpperCase() + post.category.slice(1,post.category.length),
 							},
-							navItems: posts.map((post) => ({
-								href: `/content/${post.slug}`,
-								label: post.entry.title,
+							navItems: navItemList.map((mappost) => ({
+								href: `${mappost.slug}`,
+								label: mappost.entry.title,
+								highlighted: post.title === mappost.entry.title
 							})),
 						},
 					]}

--- a/src/components/sidebar-navigation.tsx
+++ b/src/components/sidebar-navigation.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from 'framer-motion';
 import NextLink from 'next/link';
-import { notFound, usePathname } from 'next/navigation';
+import { notFound, usePathname, useSearchParams } from 'next/navigation';
 
 import { packs } from '~/lib/packs';
 import { cn, isNonEmptyArray } from '~/lib/utils';
@@ -10,13 +10,11 @@ import { cn, isNonEmptyArray } from '~/lib/utils';
 export type SidebarNavigationProps = {
 	navGroups: Array<{
 		heading: { id: string; label: string };
-		navItems: Array<{ href: string; label: string }>;
+		navItems: Array<{ href: string; label: string, highlighted?:boolean }>;
 	}>;
 };
 
 export function SidebarNavigation({ navGroups }: SidebarNavigationProps) {
-	const pathname = usePathname();
-
 	if (!isNonEmptyArray(navGroups)) return notFound();
 
 	return (
@@ -44,8 +42,7 @@ export function SidebarNavigation({ navGroups }: SidebarNavigationProps) {
 							className="flex flex-col gap-2"
 							role="list"
 						>
-							{navItems.map(({ href, label }) => {
-								const isHighlighted = pathname === href;
+							{navItems.map(({ href, label,highlighted }) => {
 								return (
 									<li key={href}>
 										<NextLink
@@ -55,14 +52,13 @@ export function SidebarNavigation({ navGroups }: SidebarNavigationProps) {
 											)}
 											href={href}
 										>
-											{isHighlighted ? (
+											{highlighted ? (
 												<span
 													aria-hidden="true"
 													className="pointer-events-none absolute inset-y-0 left-0 flex items-center"
 												>
 													<motion.span
 														className="h-3 w-0.5 rounded-r-md bg-blue-500"
-														layoutId="left-nav-indicator"
 														transition={{
 															type: 'spring',
 															bounce: 0.2,


### PR DESCRIPTION
1. In /posts sub page changed the layout left column so it will show all post categories. The title of this will be "Categories". By pressing one of the category the list of posts will be filtered to display only those posts which category were picked. User can pick more than one category if he picks 'n' categories the posts list will show all posts from those 'n' categories.
2. In /posts/[slug] changed the layout left column so it will show list of all posts from category on which user currently is. The title of this list will be category name. List item will redirect to post after click.