### PR TITLE
category filter and sidebar changes - narendran

### DIFF
--- a/src/app/(blog)/posts/[slug]/layout.tsx
+++ b/src/app/(blog)/posts/[slug]/layout.tsx
@@ -1,5 +1,4 @@
 import { notFound } from 'next/navigation';
-
 import { SidebarNavigation } from '~/components/sidebar-navigation';
 import { TableOfContents } from '~/components/table-of-contents';
 import { ThreeColumnLayout } from '~/components/three-column-layout';
@@ -17,22 +16,22 @@ export default async function PostLayout({
 	const post = await reader.collections.content.read(params.slug);
 
 	if (!post) notFound();
+	const categoryOnlyPosts = posts.filter(item => item.entry.category == post.category);
 
 	const headings = getHeadingsFromContent(await post.content());
 
 	return (
 		<ThreeColumnLayout
 			leftSidebar={
-				// TODO: Render posts only from category that current post is
 				<SidebarNavigation
 					navGroups={[
 						{
 							heading: {
 								id: 'posts-heading',
-								label: 'Posts',
+								label: post.category,
 							},
-							navItems: posts.map((post) => ({
-								href: `/content/${post.slug}`,
+							navItems: categoryOnlyPosts.map((post) => ({
+								href: `/posts/${post.slug}`,
 								label: post.entry.title,
 							})),
 						},

--- a/src/app/(blog)/posts/[slug]/page.tsx
+++ b/src/app/(blog)/posts/[slug]/page.tsx
@@ -18,7 +18,7 @@ export default async function Post({ params }: { params: { slug: string } }) {
 		<div className="prose dark:prose-invert">
 			<h1 className="text-4xl font-strong">{post.title}</h1>
 			<span>Author: {post.authors}</span>
-			<DocumentRenderer document={await post.content()} />
+			{/* <DocumentRenderer document={await post.content()} /> */}
 		</div>
 	);
 }

--- a/src/app/(blog)/posts/page.tsx
+++ b/src/app/(blog)/posts/page.tsx
@@ -1,37 +1,9 @@
-import { SidebarNavigation } from '~/components/sidebar-navigation';
-import { ThreeColumnLayout } from '~/components/three-column-layout';
-import { PostsList } from '~/components/posts-list';
 import { reader } from '~/keystatic/reader';
+import { CategoriesWrapper } from '~/components/categories-wrapper';
 
 export default async function PostsListingPage() {
 	const posts = await reader.collections.content.all();
+	const categories = await reader.collections.categories.all();
 
-	return (
-		<ThreeColumnLayout
-			leftSidebar={
-				// TODO: Replace me with categories filters
-				<SidebarNavigation
-					navGroups={[
-						{
-							heading: {
-								id: 'posts-heading',
-								label: 'Posts',
-							},
-							navItems: posts.map((post) => ({
-								href: `/content/${post.slug}`,
-								label: post.entry.title,
-							})),
-						},
-					]}
-				/>
-			}
-		>
-			<PostsList
-				posts={posts.map(({ slug, entry: { title, category } }) => ({
-					slug,
-					entry: { title, category },
-				}))}
-			/>
-		</ThreeColumnLayout>
-	);
+	return <CategoriesWrapper posts={posts} categories={categories} />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,5 +63,5 @@ export default function RootLayout({
 }: {
 	children: React.ReactNode;
 }) {
-	return children;
+	return <html><body>{children}</body></html>;
 }

--- a/src/components/categories-filter.tsx
+++ b/src/components/categories-filter.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { notFound, usePathname } from 'next/navigation';
+
+import { packs } from '~/lib/packs';
+import { cn, isNonEmptyArray } from '~/lib/utils';
+
+export type CategoriesFilterProps = {
+	navGroups: Array<{
+		heading: { id: string; label: string };
+		navItems: Array<{ slug: string; label: string }>;
+	}>;
+	filteredList: Array<string>;
+	onChange: (filter: string) => void;
+};
+
+export function CategoriesFilter({ navGroups, filteredList = [], onChange }: CategoriesFilterProps) {
+
+	if (!isNonEmptyArray(navGroups)) return notFound();
+
+	return (
+		<nav
+			aria-label="Component navigation"
+			className="hidden lg:relative lg:flex"
+		>
+			<div
+				className={cn(
+					'sticky top-[var(--header-height)] h-[calc(100dvh-var(--header-height))] flex-1 overflow-y-auto overflow-x-hidden',
+					'flex flex-col gap-4 pb-20 pt-6 text-base lg:text-sm',
+					packs.innerPadding
+				)}
+			>
+				{navGroups.map(({ heading, navItems }) => (
+					<div key={heading.id}>
+						<h2
+							className="text-lg mb-4 text-gray-900 font-strong dark:text-white"
+							id={heading.id}
+						>
+							{heading.label}
+						</h2>
+						<ul
+							aria-labelledby={heading.id}
+							className="flex flex-col gap-2"
+							role="list"
+						>
+							{navItems.map(({ slug, label }) => {
+								return (
+									<li key={slug}>
+										<label
+											className="text-md font-semibold select-none cursor-pointer text-gray-600"
+											htmlFor={slug}
+										>
+											<input
+												type="checkbox"
+												checked={filteredList.includes(slug)}
+												onClick={()=>onChange(slug)}
+												id={slug}
+											/>
+											<span className="ml-2.5">{label.toUpperCase()}</span>
+										</label>
+									</li>
+								);
+							})}
+						</ul>
+					</div>
+				))}
+			</div>
+		</nav>
+	);
+}

--- a/src/components/categories-list.tsx
+++ b/src/components/categories-list.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { notFound, usePathname } from 'next/navigation';
+
+import { packs } from '~/lib/packs';
+import { cn, isNonEmptyArray } from '~/lib/utils';
+import { CategoriesFilter } from './categories-filter';
+import { ThreeColumnLayout } from './three-column-layout';
+import { PostsList } from './posts-list';
+import { useEffect, useState } from 'react';
+import { Posts, Categories } from './categories-wrapper';
+
+export type CategoriesListProps = {
+	posts: Array<Posts>;
+	categories: Array<Categories>;
+};
+
+export function CategoriesList({ posts, categories }: CategoriesListProps) {
+	const [filteredCategories, setFilteredCategories] = useState([]);
+	const [filteredPosts, setFilteredPosts] = useState(posts);
+
+	const onFilterChange = (slug) => {
+		if (filteredCategories.includes(slug)) {
+			const newFilteredList = filteredCategories.filter(value => value != slug);
+			setFilteredCategories(newFilteredList);
+		} else {
+			setFilteredCategories([...new Set([...filteredCategories, slug])]);
+		}
+	};
+
+	useEffect(()=> {
+		if (filteredCategories.length > 0) {
+			console.log(posts);
+			const newFilteredPosts = posts.filter(post => filteredCategories.includes(post.entry.category));
+			setFilteredPosts(newFilteredPosts);
+		} else {
+			setFilteredPosts(posts);
+		}
+	}, [filteredCategories]);
+
+	return (
+		<ThreeColumnLayout
+			leftSidebar={
+				<CategoriesFilter
+					navGroups={[
+						{
+							heading: {
+								id: 'posts-heading',
+								label: 'Categories',
+							},
+							navItems: categories.map((category) => ({
+								slug: category.slug,
+								label: category.entry.category,
+							})),
+						},
+					]}
+					filteredList={filteredCategories}
+					onChange={onFilterChange}
+				/>
+			}
+		>
+			<PostsList
+				posts={filteredPosts.map(({ slug, entry: { title, category } }) => ({
+					slug,
+					entry: { title, category },
+				}))}
+			/>
+		</ThreeColumnLayout>
+	);
+}

--- a/src/components/categories-wrapper.tsx
+++ b/src/components/categories-wrapper.tsx
@@ -1,0 +1,46 @@
+'use server';
+import { CategoriesList } from './categories-list';
+
+interface Content {
+	level: number;
+	type: string;
+	children: Array<Object>;
+}
+
+interface Post {
+	category: string;
+	title: string;
+	authors?: Array<string>;
+	content?: Array<Content>;
+}
+
+export interface Posts {
+	entry: Post;
+	slug: string;
+}
+
+export interface Categories {
+	entry: {
+		category: string
+	};
+	slug: string;
+}
+
+export type CategoriesWrapperProps = {
+	posts: Array<Posts>;
+	categories: Array<Categories>;
+};
+
+export async function CategoriesWrapper({ posts, categories }: CategoriesWrapperProps) {
+	let filteredPosts = [];
+	posts.forEach((post)=> {
+		filteredPosts.push({
+			slug: post.slug,
+			entry: {
+				title: post.entry.title,
+				category: post.entry.category
+			}
+		})
+	});
+	return <CategoriesList posts={filteredPosts} categories={categories} />;
+};

--- a/src/components/sidebar-navigation.tsx
+++ b/src/components/sidebar-navigation.tsx
@@ -34,7 +34,7 @@ export function SidebarNavigation({ navGroups }: SidebarNavigationProps) {
 				{navGroups.map(({ heading, navItems }) => (
 					<div key={heading.id}>
 						<h2
-							className="text-lg text-gray-900 font-strong dark:text-white"
+							className="text-lg text-gray-900 capitalize mb-2 font-strong dark:text-white"
 							id={heading.id}
 						>
 							{heading.label}


### PR DESCRIPTION
## Change
1. In /posts sub page change the layout left column so it will show all post categories. The title of this list should be "Categories". By pressing one of the category the list of posts will be filtered to display only those posts which category were picked. User can pick more than one category if he picks 'n' categories the posts list will show all posts from those 'n' categories.
2. In /posts/[slug] change layout left column so it will show list of all posts from category on which user currently is. The title of this list should be category name. List item should redirect to post after click.

## Fix reference - Video
https://github.com/user-attachments/assets/16cb802a-31a8-4bb5-b045-c31464a318b8

## Fix reference - Screenshots
<img width="1440" alt="Change1" src="https://github.com/user-attachments/assets/e4d275bb-5992-4fde-aa63-48daf1c628cd">
<img width="1440" alt="Change2" src="https://github.com/user-attachments/assets/055f51e8-39d1-4423-94cb-af9699ee06d2">


